### PR TITLE
Correct $arguments parameter for call to SoapClient::handleFault from SoapClient::__call

### DIFF
--- a/src/SoapClient/SoapClient.php
+++ b/src/SoapClient/SoapClient.php
@@ -81,7 +81,7 @@ class SoapClient extends \SoapClient implements SoapClientInterface
                 throw $response;
             }
         } catch (\Exception $e) {
-            $this->handleFault($function_name, $arguments, $e);
+            $this->handleFault($function_name, $arguments[0] ?? [], $e);
         }
 
         return $response;


### PR DESCRIPTION
`SoapClient::handleFault()` expects a parameter array as is passed to a `SoapClient::__soapCall()` or a non-existent method `SoapClient::__call()` would be standing in for. Within `SoapClient::__call()` itself, this argument is wrapped in another array, which causes a notice when it hits `implode()` in `SoapClient::handleFault()` and will fail in stricter environments.

This passes the correct data and falls back to an empty array when no arguments were passed.