### PR TITLE
bug: not possible to lower the soap timeout

### DIFF
--- a/src/SoapClient/SoapClient.php
+++ b/src/SoapClient/SoapClient.php
@@ -161,9 +161,7 @@ class SoapClient extends \SoapClient implements SoapClientInterface
 
         /* workaround for working timeout */
         $socketTimeout = false;
-        if (isset($this->options['connection_timeout'])
-            && (int)$this->options['connection_timeout'] > (int)ini_get('default_socket_timeout')
-        ) {
+        if (isset($this->options['connection_timeout'])) {
             $socketTimeout = ini_set('default_socket_timeout', $this->options['connection_timeout']);
         }
 


### PR DESCRIPTION
It was not possible to set a lower connection timeout than the `default_socket_timeout`