### PR TITLE
refac: add native return types to fix deprecation warnings

### DIFF
--- a/src/DataCollector/AbstractSoapDataCollector.php
+++ b/src/DataCollector/AbstractSoapDataCollector.php
@@ -46,7 +46,7 @@ abstract class AbstractSoapDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'freshcells_soap_client';
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('freshcells_soap_client');
         if (method_exists($treeBuilder, 'getRootNode')) {

--- a/src/Plugin/DataCollectorPlugin.php
+++ b/src/Plugin/DataCollectorPlugin.php
@@ -62,7 +62,7 @@ class DataCollectorPlugin implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             Events::REQUEST  => 'onClientRequest',

--- a/src/Plugin/LogPlugin.php
+++ b/src/Plugin/LogPlugin.php
@@ -75,7 +75,7 @@ class LogPlugin implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             Events::REQUEST  => 'onClientRequest',


### PR DESCRIPTION
Fix deprecation warnings in symfony 5.4.
```
Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "Freshcells\SoapClientBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Freshcells\SoapClientBundle\Plugin\LogPlugin" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Freshcells\SoapClientBundle\Plugin\DataCollectorPlugin" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface::getName()" might add "string" as a native return type declaration in the future. Do the same in implementation "Freshcells\SoapClientBundle\DataCollector\AbstractSoapDataCollector" now to avoid errors or add an explicit @return annotation to suppress this message.
```