### PR TITLE
feat: only supported php & symfony versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,91 +10,40 @@ jobs:
     coding-style:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - uses: shivammathur/setup-php@v2
               with:
-                  php-version: '7.4'
+                  php-version: '8.1'
             - name: php-cs-fixer
               run: |
                   composer install -n --prefer-dist
                   composer check-style
-    tests-php-7-4-symfony-4-3:
+    tests:
+        strategy:
+            matrix:
+                php: [ 8.1, 8.2, 8.3 ]
+                symfony: [ 5.4, 6.4, 7.0 ]
+                exclude:
+                    - php: 8.1
+                      symfony: 7.0
         runs-on: ubuntu-latest
         env:
-            SYMFONY_VERSION: 4.3.*
+            SYMFONY_VERSION: ${{ matrix.symfony }}.*
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 2
             - uses: shivammathur/setup-php@v2
               with:
-                  php-version: '7.4'
+                  php-version: ${{ matrix.php }}
             - name: PHPUnit
               run: |
                   composer require --no-update symfony/config=$SYMFONY_VERSION symfony/http-kernel=$SYMFONY_VERSION symfony/dependency-injection=$SYMFONY_VERSION symfony/options-resolver=$SYMFONY_VERSION
                   composer require --no-update --dev symfony/framework-bundle=$SYMFONY_VERSION symfony/yaml=$SYMFONY_VERSION
                   composer update --prefer-dist --no-interaction --no-ansi --no-progress
                   php vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
-    tests-php-7-4-symfony-5-0:
-        runs-on: ubuntu-latest
-        env:
-            SYMFONY_VERSION: 5.0.*
-        steps:
-            - uses: actions/checkout@v2
-            - uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '7.4'
-            - name: PHPUnit
+            - name: Upload code coverage scrutinizer
+              if: ${{ matrix.php == '8.1' && matrix.symfony == '5.4' }}
               run: |
-                  composer require --no-update symfony/config=$SYMFONY_VERSION symfony/http-kernel=$SYMFONY_VERSION symfony/dependency-injection=$SYMFONY_VERSION symfony/options-resolver=$SYMFONY_VERSION
-                  composer require --no-update --dev symfony/framework-bundle=$SYMFONY_VERSION symfony/yaml=$SYMFONY_VERSION
-                  composer update --prefer-dist --no-interaction --no-ansi --no-progress
-                  php vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
-            -   name: Upload code coverage scrutinizer
-                run: |
-                    wget https://scrutinizer-ci.com/ocular.phar
-                    php ocular.phar code-coverage:upload --format=php-clover coverage.clover
-    tests-php-8-0-symfony-5-3:
-        runs-on: ubuntu-latest
-        env:
-            SYMFONY_VERSION: 5.3.*
-        steps:
-            - uses: actions/checkout@v2
-            - uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '8.0'
-            - name: PHPUnit
-              run: |
-                  composer require --no-update symfony/config=$SYMFONY_VERSION symfony/http-kernel=$SYMFONY_VERSION symfony/dependency-injection=$SYMFONY_VERSION symfony/options-resolver=$SYMFONY_VERSION
-                  composer require --no-update --dev symfony/framework-bundle=$SYMFONY_VERSION symfony/yaml=$SYMFONY_VERSION
-                  composer update --prefer-dist --no-interaction --no-ansi --no-progress
-                  php vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
-    tests-php-8-1-symfony-5-4:
-        runs-on: ubuntu-latest
-        env:
-            SYMFONY_VERSION: 5.4.*
-        steps:
-            - uses: actions/checkout@v2
-            - uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '8.1'
-            - name: PHPUnit
-              run: |
-                  composer require --no-update symfony/config=$SYMFONY_VERSION symfony/http-kernel=$SYMFONY_VERSION symfony/dependency-injection=$SYMFONY_VERSION symfony/options-resolver=$SYMFONY_VERSION
-                  composer require --no-update --dev symfony/framework-bundle=$SYMFONY_VERSION symfony/yaml=$SYMFONY_VERSION
-                  composer update --prefer-dist --no-interaction --no-ansi --no-progress
-                  php vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
-
-    tests-php-8-1-symfony-6:
-        runs-on: ubuntu-latest
-        env:
-            SYMFONY_VERSION: 6.0.*
-        steps:
-            - uses: actions/checkout@v2
-            - uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '8.1'
-            - name: PHPUnit
-              run: |
-                  composer require --no-update symfony/config=$SYMFONY_VERSION symfony/http-kernel=$SYMFONY_VERSION symfony/dependency-injection=$SYMFONY_VERSION symfony/options-resolver=$SYMFONY_VERSION
-                  composer require --no-update --dev symfony/framework-bundle=$SYMFONY_VERSION symfony/yaml=$SYMFONY_VERSION
-                  composer update --prefer-dist --no-interaction --no-ansi --no-progress
-                  php vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
+                  composer global require scrutinizer/ocular
+                  php ~/.composer/vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -24,25 +24,25 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-soap": "*",
         "ramsey/uuid": "^3.7 || ^4",
         "psr/log": "^1.1 || ^2 || ^3",
-        "symfony/config": "^4.3 || ^5.0 || ^6.0",
-        "symfony/dependency-injection": "^4.3 || ^5.0 || ^6.0",
-        "symfony/event-dispatcher": "^4.3 || ^5.0 || ^6.0",
-        "symfony/http-kernel": "^4.3 || ^5.1.5 || ^6.0"
+        "symfony/config": "^5.4 || ^6.4 || ^7.0",
+        "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.0",
+        "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.0",
+        "symfony/http-kernel": "^5.4 || ^6.4 || ^7.0"
     },
     "require-dev": {
-        "colinodell/psr-testlogger": "^1.0",
-        "phpunit/phpunit": "^8",
-        "squizlabs/php_codesniffer": "^3.5",
-        "symfony/browser-kit": "^4.3 || ^5.0 || ^6.0",
-        "symfony/debug-bundle": "^4.3 || ^5.0 || ^6.0",
-        "symfony/framework-bundle": "^4.3 || ^5.0 || ^6.0",
-        "symfony/phpunit-bridge": "^4.3 || ^5.0 || ^6.0",
-        "symfony/web-profiler-bundle": "^4.3 || ^5.0 || ^6.0",
-        "symfony/yaml": "^4.3 || ^5.0 || ^6.0"
+        "colinodell/psr-testlogger": "^1.3",
+        "phpunit/phpunit": "^9",
+        "squizlabs/php_codesniffer": "^3.10",
+        "symfony/browser-kit": "^5.4 || ^6.4 || ^7.0",
+        "symfony/debug-bundle": "^5.4 || ^6.4 || ^7.0",
+        "symfony/framework-bundle": "^5.4 || ^6.4 || ^7.0",
+        "symfony/phpunit-bridge": "^5.4 || ^6.4 || ^7.0",
+        "symfony/web-profiler-bundle": "^5.4 || ^6.4 || ^7.0",
+        "symfony/yaml": "^5.4 || ^6.4 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/DataCollector/AbstractSoapDataCollector.php
+++ b/src/DataCollector/AbstractSoapDataCollector.php
@@ -16,7 +16,7 @@ abstract class AbstractSoapDataCollector extends DataCollector
     /**
      * @see collect()
      */
-    protected function doCollect()
+    protected function doCollect(): void
     {
         $time = 0;
         foreach ($this->callRegistry->getCalls() as $call) {
@@ -30,7 +30,7 @@ abstract class AbstractSoapDataCollector extends DataCollector
         ];
     }
 
-    public function reset()
+    public function reset(): void
     {
         $this->data = [
             'total'    => 0,

--- a/src/DataCollector/SoapDataCollector.php
+++ b/src/DataCollector/SoapDataCollector.php
@@ -10,8 +10,8 @@ class SoapDataCollector extends AbstractSoapDataCollector
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, \Throwable $exception = null)
+    public function collect(Request $request, Response $response, \Throwable $exception = null): void
     {
-        return $this->doCollect();
+        $this->doCollect();
     }
 }

--- a/src/DataCollector/SoapDataCollector.php
+++ b/src/DataCollector/SoapDataCollector.php
@@ -4,32 +4,14 @@ namespace Freshcells\SoapClientBundle\DataCollector;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Kernel;
 
-// @codingStandardsIgnoreStart
-if (Kernel::MAJOR_VERSION >= 5) {
-    class SoapDataCollector extends AbstractSoapDataCollector
+class SoapDataCollector extends AbstractSoapDataCollector
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function collect(Request $request, Response $response, \Throwable $exception = null)
     {
-// @codingStandardsIgnoreEnd
-        /**
-         * {@inheritdoc}
-         */
-        public function collect(Request $request, Response $response, \Throwable $exception = null)
-        {
-            return $this->doCollect();
-        }
-    }
-} else {
-// @codingStandardsIgnoreStart
-    class SoapDataCollector extends AbstractSoapDataCollector
-    {
-// @codingStandardsIgnoreEnd
-        /**
-         * {@inheritdoc}
-         */
-        public function collect(Request $request, Response $response, \Exception $exception = null)
-        {
-            return $this->doCollect();
-        }
+        return $this->doCollect();
     }
 }

--- a/src/DependencyInjection/CompilerPass/ClientCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/ClientCompilerPass.php
@@ -10,7 +10,7 @@ class ClientCompilerPass implements CompilerPassInterface
 {
     const CLIENT_TAG = 'freshcells_soap_client.client';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $clients = $container->findTaggedServiceIds(self::CLIENT_TAG);
 

--- a/src/DependencyInjection/FreshcellsSoapClientExtension.php
+++ b/src/DependencyInjection/FreshcellsSoapClientExtension.php
@@ -17,7 +17,7 @@ class FreshcellsSoapClientExtension extends Extension
     /**
      * {@inheritDoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config        = $this->processConfiguration($configuration, $configs);

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -1,22 +1,9 @@
 <?php
 
-
 namespace Freshcells\SoapClientBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event as ComponentEvent;
 use Symfony\Contracts\EventDispatcher\Event as ContractEvent;
 
-// Symfony 4.3 BC layer
-if (class_exists(ContractEvent::class)) {
-// @codingStandardsIgnoreStart
-    abstract class Event extends ContractEvent
-    {
-// @codingStandardsIgnoreEnd
-    }
-} else {
-// @codingStandardsIgnoreStart
-    abstract class Event extends ComponentEvent
-    {
-// @codingStandardsIgnoreEnd
-    }
+abstract class Event extends ContractEvent
+{
 }

--- a/src/FreshcellsSoapClientBundle.php
+++ b/src/FreshcellsSoapClientBundle.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class FreshcellsSoapClientBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/SoapClient/SoapClient.php
+++ b/src/SoapClient/SoapClient.php
@@ -9,7 +9,6 @@ use Freshcells\SoapClientBundle\Event\RequestEvent;
 use Freshcells\SoapClientBundle\Event\ResponseEvent;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * Class SoapClient
@@ -276,13 +275,6 @@ class SoapClient extends \SoapClient implements SoapClientInterface
             return;
         }
 
-        // EventDispatcher signature changed in Symfony 4.3
-        if (Kernel::VERSION_ID < 40300) {
-            // Old EventDispatcher signature
-            $this->dispatcher->dispatch($eventName, $event);
-        } else {
-            // New Symfony 4.3 EventDispatcher signature
-            $this->dispatcher->dispatch($event, $eventName);
-        }
+        $this->dispatcher->dispatch($event, $eventName);
     }
 }

--- a/src/SoapClient/SoapClient.php
+++ b/src/SoapClient/SoapClient.php
@@ -9,6 +9,7 @@ use Freshcells\SoapClientBundle\Event\RequestEvent;
 use Freshcells\SoapClientBundle\Event\ResponseEvent;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * Class SoapClient
@@ -241,8 +242,8 @@ class SoapClient extends \SoapClient implements SoapClientInterface
 
     /**
      * @param EventDispatcherInterface $dispatcher
-     * @required
      */
+    #[Required]
     public function setDispatcher(EventDispatcherInterface $dispatcher)
     {
         $this->dispatcher = $dispatcher;


### PR DESCRIPTION
Drop unsupported php & symfony versions.

* php 8.1, 8.2, 8.3 see https://www.php.net/supported-versions.php
* symfony 5.4, 6.4, 7.0 see https://symfony.com/releases
* update phpunit to support coverage for php8
* use matrix for github actions
* exclude php 8.1 & symfony 7 because symfony 7 requires php >=8.2

Clean code
* fix deprecations
* remove bc layers
* replace required annotation by attribute

fix all deprecations from #29