### PR TITLE
bug: data provider xml content add css overflow

### DIFF
--- a/src/Resources/views/Collector/soap.html.twig
+++ b/src/Resources/views/Collector/soap.html.twig
@@ -70,6 +70,7 @@
             margin: .5em 0;
             padding: 1em;
             border: 1px solid #DDD;
+            overflow: scroll;
         }
         .theme-dark .soap-xml-container {
             background: #36393e;


### PR DESCRIPTION
before:
![grafik](https://github.com/freshcells/soap-client-bundle/assets/200904/51af5cd4-e682-421f-83c7-eb2d41b82281)

after
![grafik](https://github.com/freshcells/soap-client-bundle/assets/200904/c95a0cc0-fb19-4085-8a73-c1ac930039fd)
