### PR TITLE
PHP8.4 deprecation spam: change implicit nullable type to explicit nullable

### DIFF
--- a/src/DataCollector/SoapDataCollector.php
+++ b/src/DataCollector/SoapDataCollector.php
@@ -10,7 +10,7 @@ class SoapDataCollector extends AbstractSoapDataCollector
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, \Throwable $exception = null): void
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
         $this->doCollect();
     }

--- a/src/SoapClient/SoapClient.php
+++ b/src/SoapClient/SoapClient.php
@@ -187,7 +187,7 @@ class SoapClient extends \SoapClient implements SoapClientInterface
      * @param string $resource
      * @param string $requestContent
      */
-    protected function preCall(string $id, string $resource, string $requestContent = null)
+    protected function preCall(string $id, string $resource, ?string $requestContent = null)
     {
         $this->dispatch(new RequestEvent($id, $resource, $requestContent), Events::REQUEST);
     }
@@ -197,7 +197,7 @@ class SoapClient extends \SoapClient implements SoapClientInterface
      * @param string $resource
      * @param string $response
      */
-    protected function postCall(string $id, string $resource, string $response = null)
+    protected function postCall(string $id, string $resource, ?string $response = null)
     {
         $responseEvent = new ResponseEvent(
             $id,


### PR DESCRIPTION
In PHP8.4 we get a lot of deprecation spam from implicit nullable types.
This should be BC.