### PR TITLE
refac: change import from HttpKernel to DependencyInjection

### DIFF
--- a/src/DependencyInjection/FreshcellsSoapClientExtension.php
+++ b/src/DependencyInjection/FreshcellsSoapClientExtension.php
@@ -10,7 +10,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 class FreshcellsSoapClientExtension extends Extension
 {


### PR DESCRIPTION
Fix deprecation message:
```
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Freshcells\SoapClientBundle\DependencyInjection\FreshcellsSoapClientExtension".
```