### PR TITLE
bug: SoapCallRegistry::prettyXML avoid E_WARNING with no xml content

### DIFF
--- a/src/DataCollector/SoapCallRegistry.php
+++ b/src/DataCollector/SoapCallRegistry.php
@@ -38,6 +38,7 @@ class SoapCallRegistry
 
     private function prettyXML(string $xml): string
     {
+        $previous = libxml_use_internal_errors(true);
         try {
             //nicen
             $doc = new \DomDocument('1.0');
@@ -45,8 +46,8 @@ class SoapCallRegistry
             $doc->formatOutput = true;
 
             return $doc->saveXML();
-        } catch (\Exception $e) {
-            // probably no xml, just let it pass
+        } finally {
+            libxml_use_internal_errors($previous);
         }
 
         return $xml;


### PR DESCRIPTION
When the response is not xml content in our case pdf file. We getting an php warning.

```
Warning: DOMDocument::loadXML(): Start tag expected, '<' not found in Entity, line: 2
```